### PR TITLE
Add boolean literals to textMate file

### DIFF
--- a/syntaxes/lox.tmLanguage.json
+++ b/syntaxes/lox.tmLanguage.json
@@ -36,6 +36,10 @@
 					"match": "\\b(nil)\\b"
 				},
 				{
+					"name": "constant.language.boolean.lox",
+					"match": "\\b(true|false)\\b"
+				},
+				{
 					"name": "support.function.builtin.lox",
 					"match": "\\b(print)\\b"
 				},


### PR DESCRIPTION
Thanks for making this extension. I noticed as I was working through my own implementation of lox that `true` and `false` weren't given special treatment like `nil`. This just adds these to the grammer