### PR TITLE
fix repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/danman113/lox-language.git"
+        "url": "https://github.com/danman113/lox-language.git"
     },
     "keywords": [
         "lox",


### PR DESCRIPTION
Clicking the Repository link on the store page doesn't work:
<img width="529" alt="image" src="https://user-images.githubusercontent.com/10628294/99900897-ee5ff900-2cb2-11eb-9ae7-309c45f0d73c.png">

According to [the extension manifest documentation](https://code.visualstudio.com/api/references/extension-manifest) you're not supposed to add the `git+` prefix.