### PR TITLE
added syntax highlighting for operators

### DIFF
--- a/syntaxes/lox.tmLanguage.json
+++ b/syntaxes/lox.tmLanguage.json
@@ -22,6 +22,9 @@
 		},
 		{
 			"include": "#digits"
+		},
+		{
+			"include": "#operators"
 		}
 	],
 	"repository": {
@@ -139,6 +142,22 @@
 				{
 					"name": "comment.line.double-slash.lox",
 					"match": "\\/\\/.*"
+				}
+			]
+		},
+		"operators": {
+			"patterns": [				
+				{
+					"match": "(==|!=|<=?|>=?)",
+					"name": "keyword.operator.comparison.lox"
+				},
+				{
+					"match": "=",
+					"name": "keyword.operator.assignment.lox"
+				},
+				{
+					"match": "(\\+|\\-|\\*|\\/)",
+					"name": "keyword.operator.arithmetic.lox"
 				}
 			]
 		}


### PR DESCRIPTION
Hi,

First of all I want to thank you for creating the extension.
I created my own vscode-extension based on your extension for my own flavor of lox.
For that purpose I added syntax highlighting for operators and I thought maybe you would also like to add that to your vscode extension.