### PR TITLE
Allow underscores in function parameters

### DIFF
--- a/syntaxes/lox.tmLanguage.json
+++ b/syntaxes/lox.tmLanguage.json
@@ -67,7 +67,7 @@
 					}
 				},
 				{
-					"match": "\\b(fun)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([A-Za-z0-9,\\s]*)\\)",
+					"match": "\\b(fun)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([A-Za-z0-9_,\\s]*)\\)",
 					"captures": {
 						"1": {
 							"name":"storage.type.function.lox"


### PR DESCRIPTION
Syntax highlighting would break for a `fun` keyword, function name, and parameter names if a function definition had parameters containing underscores. Crafting Interpreters specifies that underscores are allowed in Lox identifiers.

I have extended the grammar to allow underscores in function parameters.
